### PR TITLE
feat: add TWZRD Agent Intel for persistent agent identity memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ This taxonomy maps directly to the three primary application scenarios that orga
 | 2024-07 | AriGraph: Learning knowledge graph world models with episodic memory for LLM agents | [![Paper](https://img.shields.io/badge/paper-A42C25?style=for-the-badge&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2407.04363) |
 | 2024-06 | QRMeM: Unleash the Length Limitation through Question then Reflection Memory Mechanism | [![Paper](https://img.shields.io/badge/paper-A42C25?style=for-the-badge&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2406.13167) |
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Persistent on-chain identity and trust memory for AI agents on Solana. Agent wallets accumulate behavioral history used for autonomy scoring and identity verification. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 ### Survey
 
 | Date | Title | Paper | GitHub |


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Application section.

TWZRD Agent Intel creates **persistent on-chain memory** for AI agent wallets — their Solana transaction history becomes a behavioral memory store that can be queried for trust scoring. This is a novel form of agent memory: immutable, verifiable, and cross-session.

Relevant for: multi-agent memory architectures, agent identity continuity, trust propagation in agent networks.

**Free MCP config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```