### PR TITLE
Add ForeDreamer to learning from experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This taxonomy maps directly to the three primary application scenarios that orga
 
 | Date | Title | Paper |
 |:------:|:------|:------:|
+| 2026-08 | ForeDreamer: A Self-Evolving Dual-Agent Memory Architecture for Future Event Prediction | [![Paper](https://img.shields.io/badge/paper-A42C25?style=for-the-badge&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.20920) |
 | 2026-01 | Controlled Self-Evolution for Algorithmic Code Optimization | [![Paper](https://img.shields.io/badge/paper-A42C25?style=for-the-badge&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2601.07348) |
 | 2026-01 | Beyond Static Tools: Test-Time Tool Evolution for Scientific Reasoning | [![Paper](https://img.shields.io/badge/paper-A42C25?style=for-the-badge&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2601.07641) |
 | 2026-01 | MemGovern: Enhancing Code Agents through Learning from Governed Human Experiences | [![Paper](https://img.shields.io/badge/paper-A42C25?style=for-the-badge&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2601.06789) |


### PR DESCRIPTION
## Summary

Adds “ForeDreamer: A Self-Evolving Dual-Agent Memory Architecture for Future Event Prediction,” accepted to Findings of EMNLP 2026, to Learning from Experience.

## Why it belongs

The method accumulates reusable forecasting experience across tasks while evolving memory-processing procedures, aligning with cross-task experience accumulation and transfer.

## Links

- Paper: https://arxiv.org/abs/2608.20920
- Code: https://github.com/zhongzero/ForeDreamer
- Project: https://zhongzero.github.io/ForeDreamer/

## Disclosure

I am an author of this paper.
